### PR TITLE
Use lua_pushinteger instead of lua_pushunsigned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SOLIB    = ${BUILDDIR}/sysctl.so
 DESTDIR ?= sysctl
 
 LDFLAGS += -shared -Wl,-soname,${SONAME}
-CFLAGS  += -Wall -Wextra -fPIC `pkg-config --cflags ${LUA_VER}`
+CFLAGS  += -Wall -Wextra -fPIC `pkg-config --cflags lua-${LUA_VER}`
 
 all: ${SOLIB}
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
+LUA_VER ?= 5.2
 SONAME   = lua_sysctl
 BUILDDIR = build
 SOLIB    = ${BUILDDIR}/sysctl.so
 DESTDIR ?= sysctl
 
 LDFLAGS += -shared -Wl,-soname,${SONAME}
-CFLAGS  += -Wall -Wextra -fPIC `pkg-config --cflags lua-5.2`
+CFLAGS  += -Wall -Wextra -fPIC `pkg-config --cflags ${LUA_VER}`
 
 all: ${SOLIB}
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ lua version if you want to build.
 
 Reading:
 ```
-> require('sysctl')
+> sysctl = require('sysctl')
 > val, type = sysctl.get('kern.ostype') -- reading a string
 > print(val)
 FreeBSD
@@ -61,7 +61,7 @@ avm 420396
 
 Writting:
 ```
-> require('sysctl')
+> sysctl = require('sysctl')
 > sysctl.set('security.bsd.see_other_uids', 0)
 ```
 

--- a/src/lua_sysctl.c
+++ b/src/lua_sysctl.c
@@ -61,6 +61,13 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+/*
+ * lua 5.3+ define LUA_MAXINTEGER, but lua 5.2 does not. See
+ * https://www.lua.org/manual/5.2/manual.html#lua_Integer
+ */
+#ifndef LUA_MAXINTEGER
+#define LUA_MAXINTEGER  PTRDIFF_MAX
+#endif
 
 /* NOTE: our signature of oidfmt differ from sysctl.c because we check for the
    buffer's size */
@@ -514,7 +521,7 @@ luaA_sysctl_get(lua_State *L)
 				else
 					lua_pushinteger(L, mv);
 			} else {
-				if (intlen > sizeof(lua_Integer))
+				if (umv > LUA_MAXINTEGER)
 					lua_pushnumber(L, umv);
 				else
 					lua_pushinteger(L, (lua_Integer)(umv));

--- a/src/lua_sysctl.c
+++ b/src/lua_sysctl.c
@@ -517,7 +517,7 @@ luaA_sysctl_get(lua_State *L)
 				if (intlen > sizeof(lua_Unsigned))
 					lua_pushnumber(L, umv);
 				else
-					lua_pushunsigned(L, umv);
+				        lua_pushinteger(L, (lua_Integer)(umv));
 			}
 			lua_settable(L, -3);
 			len -= intlen;

--- a/src/lua_sysctl.c
+++ b/src/lua_sysctl.c
@@ -514,10 +514,10 @@ luaA_sysctl_get(lua_State *L)
 				else
 					lua_pushinteger(L, mv);
 			} else {
-				if (intlen > sizeof(lua_Unsigned))
+				if (intlen > sizeof(lua_Integer))
 					lua_pushnumber(L, umv);
 				else
-				        lua_pushinteger(L, (lua_Integer)(umv));
+					lua_pushinteger(L, (lua_Integer)(umv));
 			}
 			lua_settable(L, -3);
 			len -= intlen;


### PR DESCRIPTION
Use `lua_pushinteger` instead of `lua_pushunsigned` to make it compatible with lua 5.3+. 

Tested on LUA 5.2, 5.3 and 5.4 versions.