### PR TITLE
Apply DragonFly downstream patch by zrj-rimwis (from DeltaPorts)

### DIFF
--- a/src/lua_sysctl.c
+++ b/src/lua_sysctl.c
@@ -273,10 +273,12 @@ luaA_sysctl_set(lua_State *L)
 	if ((kind & CTLTYPE) == CTLTYPE_NODE)
 		return (luaL_error(L, "oid '%s' isn't a leaf node", bufp));
 	if (!(kind & CTLFLAG_WR)) {
+#ifndef __DragonFly__
 		if (kind & CTLFLAG_TUN)
 			return (luaL_error(L, "oid '%s' is a read only tunable. "
 					"Tunable values are set in /boot/loader.conf", bufp));
 		else
+#endif
 			return (luaL_error(L, "oid '%s' is read only", bufp));
 	}
 


### PR DESCRIPTION
I don't know the exact technical reasons behind this patch (I'm not a dfly user), but this is what both Dports and Ravenports apply to the lua-sysctl port.